### PR TITLE
feat: button upgraded to support icons

### DIFF
--- a/src/components/button.stories.tsx
+++ b/src/components/button.stories.tsx
@@ -114,6 +114,14 @@ export const Loading: Story = {
   ),
 };
 
+export const LoadingWithIcon: Story = {
+  args: {
+    label: "Start Sync",
+    loading: true,
+    icon: <Mail className="h-4 w-4" />,
+  },
+};
+
 export const WithClickHandler: Story = {
   args: {
     children: "Click me",

--- a/src/components/button.test.tsx
+++ b/src/components/button.test.tsx
@@ -34,4 +34,28 @@ describe("Button", () => {
     render(<Button size="lg">Large</Button>);
     expect(screen.getByRole("button")).toHaveTextContent("Large");
   });
+
+  it("shows spinner and keeps icon visible while loading", () => {
+    render(
+      <Button loading icon={<svg data-testid="button-icon" aria-hidden="true" />}>
+        Sync
+      </Button>,
+    );
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByTestId("button-icon")).toBeInTheDocument();
+    expect(button.querySelector(".animate-spin")).toBeTruthy();
+  });
+
+  it("supports a custom loading indicator", () => {
+    render(
+      <Button loading loadingIndicator={<span data-testid="custom-loader" />}>
+        Save
+      </Button>,
+    );
+
+    expect(screen.getByTestId("custom-loader")).toBeInTheDocument();
+  });
 });

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -77,6 +77,12 @@ export interface ButtonProps
   loading?: boolean;
 
   /**
+   * Optional custom loading indicator rendered before content when `loading` is true.
+   * @example <Button loading loadingIndicator={<Spinner />} />
+   */
+  loadingIndicator?: React.ReactNode;
+
+  /**
    * Icon element to render alongside the label.
    * Position controlled by `iconPosition`.
    * @example <Button icon={<PlusIcon />} label="Add Item" />
@@ -99,6 +105,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       asChild = false,
       label,
       loading = false,
+      loadingIndicator,
       icon,
       iconPosition = "start",
       children,
@@ -107,8 +114,9 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) => {
-    // Config API: use label as children if no children provided
-    const content = children ?? label;
+    // Config API: use label when children are not provided
+    const hasChildren = children !== undefined && children !== null;
+    const content = hasChildren ? children : label;
 
     if (asChild) {
       return (
@@ -125,12 +133,19 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         disabled={disabled || loading}
+        aria-busy={loading || undefined}
         {...props}
       >
-        {loading && <Loader2 className="h-4 w-4 animate-spin" />}
-        {!loading && icon && iconPosition === "start" && icon}
-        {content && <span className={loading ? "opacity-70" : undefined}>{content}</span>}
-        {!loading && icon && iconPosition === "end" && icon}
+        {loading &&
+          (loadingIndicator ?? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />)}
+        {icon && iconPosition === "start" && icon}
+        {content &&
+          (hasChildren ? (
+            content
+          ) : (
+            <span className={loading ? "opacity-70" : undefined}>{content}</span>
+          ))}
+        {icon && iconPosition === "end" && icon}
       </button>
     );
   },


### PR DESCRIPTION
This pull request enhances the `Button` component by improving its loading state handling and adding support for custom loading indicators. It also updates the component's tests and stories to cover these new behaviors.

**Button loading state improvements:**

* Added a new `loadingIndicator` prop to `ButtonProps`, allowing consumers to provide a custom loading indicator when the button is in the loading state.
* Updated the `Button` component to render the custom loading indicator if provided, otherwise defaulting to the existing spinner. The button now also sets `aria-busy` when loading for better accessibility. [[1]](diffhunk://#diff-75263585659a8bab44b44bd4758c7d5f38342f11f856d3b659ff5fd21010cd95R108) [[2]](diffhunk://#diff-75263585659a8bab44b44bd4758c7d5f38342f11f856d3b659ff5fd21010cd95L110-R119) [[3]](diffhunk://#diff-75263585659a8bab44b44bd4758c7d5f38342f11f856d3b659ff5fd21010cd95R136-R148)

**Testing and documentation:**

* Added new tests to verify that the button displays both the spinner and icon during loading, and supports a custom loading indicator.
* Added a new story, `LoadingWithIcon`, to demonstrate the button with both loading and icon states.